### PR TITLE
Fix DB migration issue on install due mysql timestamp invalid default…

### DIFF
--- a/database/migrations/5_2_35_0_create_page_versions_schedule.php
+++ b/database/migrations/5_2_35_0_create_page_versions_schedule.php
@@ -20,7 +20,7 @@ class CreatePageVersionsSchedule extends Migration
             $table->create();
             $table->increments('id');
             $table->integer('page_version_id');
-            $table->timestamp('live_from');
+            $table->timestamp('live_from')->useCurrent();
             $table->integer('repeat_in')->default(0);
             $table->string('repeat_in_func')->nullable();
             $table->timestamps();


### PR DESCRIPTION
… value
Notes: http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_date
