### PR TITLE
Make migrations publishable

### DIFF
--- a/src/CmsServiceProvider.php
+++ b/src/CmsServiceProvider.php
@@ -67,6 +67,11 @@ class CmsServiceProvider extends ServiceProvider
             });
         }
 
+        // make migrations publishable
+        $this->publishes([
+            __DIR__.'/../database/migrations/' => database_path().'/migrations/'
+        ], 'migrations');
+
         // set cookie jar for cookies
         Auth::setCookieJar($this->app['cookie']);
 


### PR DESCRIPTION
It's just a personal preference, but I love to see all my migrations in one place. So it would be awesome if you implement this little feature.

To publish coastercms migrations one would run `php artisan vendor:publish --provider="web-feet/coasterframework/CmsServiceProvider"`